### PR TITLE
implement simple example of afk fishing system

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,7 @@ worlds:
     drop_rate: 10
     boss_drop_rate: 10                      #NOTE: Boss drop rate OVERRIDES common drop rate, for bosses-only.
     quest_rate: 5                           #Multiplier for Exp & Meso gains when completing a quest. Only available when USE_QUEST_RATE is true. Stacks with server Exp & Meso rates.
-    fishing_rate: 10                        #Multiplier for success likelihood on meso thrown during fishing.
+    fishing_rate: 1                         #Flat bonus success % for fishing. must be 0-10 (or negative if you're a dick)
     travel_rate: 10                         #Means of transportation rides/departs using 1/N of the default time.
 
     #Properties for Bera 1

--- a/src/main/java/client/command/commands/gm4/FishingRateCommand.java
+++ b/src/main/java/client/command/commands/gm4/FishingRateCommand.java
@@ -42,7 +42,14 @@ public class FishingRateCommand extends Command {
         }
 
         int fishrate = Math.max(Integer.parseInt(params[0]), 1);
-        c.getWorldServer().setFishingRate(fishrate);
-        c.getWorldServer().broadcastPacket(PacketCreator.serverNotice(6, "[Rate] Fishing Rate has been changed to " + fishrate + "x."));
+        if(fishrate >= 0 && fishrate <= 10)
+        {
+            c.getWorldServer().setFishingRate(fishrate);
+            c.getWorldServer().broadcastPacket(PacketCreator.serverNotice(6, "[Rate] Fishing Rate bonus has been changed to +" + fishrate + "%."));
+        }
+        else
+        {
+            player.yellowMessage("Fishing rate must be 0-10");
+        }
     }
 }

--- a/src/main/java/constants/game/GameConstants.java
+++ b/src/main/java/constants/game/GameConstants.java
@@ -28,7 +28,9 @@ public class GameConstants {
     private static final int[] DROP_RATE_GAIN = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
     private static final int[] MESO_RATE_GAIN = {1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78, 91, 105};
     private static final int[] EXP_RATE_GAIN = {1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610};    //fibonacci :3
-
+    //Fishing System
+    public static final int[] FISHING_BAIT_STRENGTH = {400, 200, 100};
+    public static final int FISHING_INTERVAL = 60; //seconds
     private static final int[] jobUpgradeBlob = {1, 20, 60, 110, 190};
     private static final int[] jobUpgradeSpUp = {0, 1, 2, 3, 6};
     private final static Map<Integer, String> jobNames = new HashMap<>();

--- a/src/main/java/constants/id/ItemId.java
+++ b/src/main/java/constants/id/ItemId.java
@@ -1,5 +1,7 @@
 package constants.id;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.IntStream;
 
 public class ItemId {
@@ -65,6 +67,182 @@ public class ItemId {
     public static boolean isChair(int itemId) {
         return itemId >= CHAIR_MIN && itemId <= CHAIR_MAX;
         // alt: return itemId / 10000 == 301;
+    }
+
+    // Fishing items - set to some implemented item you wish to use as bait.
+    public static final int TIER_1_BAIT = 2466001;
+    public static final int TIER_2_BAIT = 2466002;
+    public static final int TIER_3_BAIT = 2466003;
+
+    // Rewards lists -- change to what you want. TODO - load this from DB with weight instead of this sloppy way
+    public static int [] FISHING_REWARDS_COMMON = {
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4001126, // Maple Leaf
+            4001126, // Maple Leaf
+            4001126, // Maple Leaf
+            4001126, // Maple Leaf
+            2002016, // Thief Elixir
+            2002017, // Warrior Elixir
+            2002018, // Wizard Elixir
+            2002019, // Archer Elixir
+            2022456, // Elixir
+            2022456, // Elixir
+            2022456, // Elixir
+            2022456, // Elixir
+            2002011, // Pain Reliever
+            2002011, // Pain Reliever
+            2002027, // Stirg Signal
+            2002027, // Stirg Signal
+            2050004, // All Cure Potion
+            2050004, // All Cure Potion
+            1072043, // Smelly Gomushin
+            1082002, // Work Gloves
+            2466000, // Ore Pack
+            2210000, // Orange Mushroom transformation
+            2210001, // Ribbon Pig transformation
+            2210002, // Alien transformation
+            2100120, // Snail Summoning Sack
+            2100121, // Slime Summoning Sack
+            2100124, // Pig Summoning Sack
+            2100126, // Orange Mushroom Summoning Sack
+            2049000, // 1% Slate
+            2049000, // 1% Slate
+            2049000, // 1% Slate
+            2049000  // 1% Slate
+    };
+
+    public static int [] FISHING_REWARDS_UNCOMMON = {
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            2466000, // Ore Pack
+            2466000, // Ore Pack
+            2466000, // Ore Pack
+            2022457, // Power Elixir
+            2022457, // Power Elixir
+            2022457, // Power Elixir
+            2022457, // Power Elixir
+            2022117, // Maple Syrup Buff
+            2466002, // Better Bait
+            2466002, // Better Bait
+            2466002, // Better Bait
+            2466002, // Better Bait
+            1002089, // Green Bamboo Hat
+            1002090, // Blue Bamboo Hat
+            1002026, // Brown Bamboo Hat
+            1002492, // White Baseball Cap
+            1102080, // Ragged Blue Cape
+            1102083, // Ragged Green Cape
+            1002455, // Black Starry Bandana
+            1072261, // Yellow Strap Shoes
+            1072262, // Black Strap Shoes
+            1072263, // Green Strap Shoes
+            1072264, // Silver Strap Shoes
+            2049001, // 3% clean slate
+            2049001, // 3% clean slate
+            2049001, // 3% clean slate
+            2049001, // 3% clean slate
+            2043001, // 1H Sword ATT 60%
+            2043101, // 1H Axe ATT 60%
+            2043201, // 1H BW ATT 60%
+            2043301, // Dagger ATT 60%
+            2043701, // Wand MATT 60%
+            2043801, // Staff MATT 60%
+            2044001, // 2H Sword ATT 60%
+            2044101, // 2H Axe ATT 60%
+            2044201, // 2H BW ATT 60%
+            2044301, // Spear ATT 60%
+            2044401, // Polearm ATT 60%
+            2044501, // Bow ATT 60%
+            2044601, // Xbow ATT 60%
+            2044701, // Claw ATT 60%
+            2044801, // Knuckle ATT 60%
+            2044902  // Gun ATT 60%
+    };
+
+    public static int [] FISHING_REWARDS_RARE = {
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            4310002, // Fishing Coin
+            5220000, // Gachapon Coin
+            5220000, // Gachapon Coin
+            1432039, // Fishing Pole
+            1012071, // Choco Icecream Bar
+            1012072, // Melon Icecream Bar
+            1012073, // Watermelon Icecream Bar
+            1002788, // Necomimi
+            2049100, // Chaos Scroll 60%
+            2040826, // GFA 60%
+            2040817, // GFMA 60%
+            2466003, // Quality Bait
+            2466003, // Quality Bait
+            2466003, // Quality Bait
+            2466003, // Quality Bait
+            2002015, // Elpam Elixir
+            1002584, // Red Old Wisconsin
+            1002585, // Blue Old Wisconsin
+            1002586, // Purple Old Wisonsin
+            1002587, // Black Old Wisconsin
+            1002195, // Flowery Swimming Cap (NX)
+            1002311, // Traveler's Hat (NX)
+            1002418, // Newspaper Hat
+            1012107, // Branch Nose
+            1012071, // Shabby Mask
+            1102043, // Brown Adventurer Cape
+            1051140, // Yellow Bath Towel (F)
+            1050127, // Bath Towel (Black) (M)
+            2049004, // clean slate 10%
+            2049004, // clean slate 10%
+            2049004, // clean slate 10%
+            2022068, // yellow cider (magic att +35 buff)
+            2022069, // red cider (attack + 34 buff)
+            2044712, // scroll for claw for att 100% (white 100%s)
+            2044612, // scroll for Xbow for att 100% (white 100%s)
+            2044512, // scroll for bow for att 100% (white 100%s)
+            2044417, // scroll for polearm for att 100% (white 100%s)
+            2044317, // scroll for spear for att 100% (white 100%s)
+            2044217, // scroll for 2H BW for att 100% (white 100%s)
+            2044117, // scroll for 2H Axe for att 100% (white 100%s)
+            2044025, // scroll for 2H sword for att 100% (white 100%s)
+            2043812, // scroll for Staff for matt 100% (white 100%s)
+            2043712, // scroll for Wand for matt 100% (white 100%s)
+            2043312, // scroll for Dagger for att 100% (white 100%s)
+            2043217, // scroll for 1H BW for att 100% (white 100%s)
+            2043117, // scroll for 1H axe for att 100% (white 100%s)
+            2043023, // scroll for 1H sword for att 100% (white 100%s)
+            2044815, // scroll for knuckle for att 100% (white 100%s)
+            2044908, // scroll for gun for att 100% (white 100%s)
+    };
+
+    // This identifies which items in the rewards lists above should trigger
+    // a server-wide message announcing the catch. Obviously, any items here
+    // should be in the above lists somewhere. This is not a separate tier.
+    private static List<String> jackpots = Arrays.asList(
+            "2049100");
+
+    public static boolean isJackpotFishingDrop(int itemId){
+        // TODO - move this to the DB and load
+        return jackpots.contains(String.valueOf(itemId));
     }
 
     // Throwing star

--- a/src/main/java/constants/id/MapId.java
+++ b/src/main/java/constants/id/MapId.java
@@ -235,7 +235,7 @@ public class MapId {
         return mapId >= NETTS_PYRAMID_MIN && mapId <= NETTS_PYRAMID_MAX;
     }
 
-    // Fishing
+    // Fishing - you'll probably want to change these maps.
     private static final int ON_THE_WAY_TO_THE_HARBOR = 120010000;
     private static final int PIER_ON_THE_BEACH = 251000100;
     private static final int PEACEFUL_SHIP = 541010110;

--- a/src/main/java/net/server/channel/handlers/MesoDropHandler.java
+++ b/src/main/java/net/server/channel/handlers/MesoDropHandler.java
@@ -64,10 +64,7 @@ public final class MesoDropHandler extends AbstractPacketHandler {
             return;
         }
 
-        if (player.attemptCatchFish(meso)) {
-            player.getMap().disappearingMesoDrop(meso, player, player, player.getPosition());
-        } else {
-            player.getMap().spawnMesoDrop(meso, player.getPosition(), player, player, true, (byte) 2);
-        }
+        player.getMap().spawnMesoDrop(meso, player.getPosition(), player, player, true, (byte) 2);
+
     }
 }

--- a/src/main/java/net/server/world/World.java
+++ b/src/main/java/net/server/world/World.java
@@ -199,7 +199,7 @@ public class World {
         charactersSchedule = tman.register(new CharacterAutosaverTask(this), HOURS.toMillis(1), HOURS.toMillis(1));
         marriagesSchedule = tman.register(new WeddingReservationTask(this), MINUTES.toMillis(YamlConfig.config.server.WEDDING_RESERVATION_INTERVAL), MINUTES.toMillis(YamlConfig.config.server.WEDDING_RESERVATION_INTERVAL));
         mapOwnershipSchedule = tman.register(new MapOwnershipTask(this), SECONDS.toMillis(20), SECONDS.toMillis(20));
-        fishingSchedule = tman.register(new FishingTask(this), SECONDS.toMillis(10), SECONDS.toMillis(10));
+        fishingSchedule = tman.register(new FishingTask(this), SECONDS.toMillis(GameConstants.FISHING_INTERVAL), SECONDS.toMillis(GameConstants.FISHING_INTERVAL));
         partySearchSchedule = tman.register(new PartySearchTask(this), SECONDS.toMillis(10), SECONDS.toMillis(10));
         timeoutSchedule = tman.register(new TimeoutTask(this), SECONDS.toMillis(10), SECONDS.toMillis(10));
         hpDecSchedule = tman.register(new CharacterHpDecreaseTask(this), YamlConfig.config.server.MAP_DAMAGE_OVERTIME_INTERVAL, YamlConfig.config.server.MAP_DAMAGE_OVERTIME_INTERVAL);
@@ -2043,13 +2043,13 @@ public class World {
         }
     }
 
-    public boolean registerFisherPlayer(Character chr, int baitLevel) {
+    public boolean registerFisherPlayer(Character chr) {
         synchronized (fishingAttempters) {
             if (fishingAttempters.containsKey(chr)) {
                 return false;
             }
 
-            fishingAttempters.put(chr, baitLevel);
+            fishingAttempters.put(chr, 1);
             return true;
         }
     }
@@ -2064,8 +2064,6 @@ public class World {
     }
 
     public void runCheckFishingSchedule() {
-        double[] fishingLikelihoods = Fishing.fetchFishingLikelihood();
-        double yearLikelihood = fishingLikelihoods[0], timeLikelihood = fishingLikelihoods[1];
 
         if (!fishingAttempters.isEmpty()) {
             List<Character> fishingAttemptersList;
@@ -2075,8 +2073,14 @@ public class World {
             }
 
             for (Character chr : fishingAttemptersList) {
-                int baitLevel = unregisterFisherPlayer(chr);
-                Fishing.doFishing(chr, baitLevel, yearLikelihood, timeLikelihood);
+                if(!chr.isLoggedinWorld() || !chr.isAlive() || chr.getChair() == -1){
+                    unregisterFisherPlayer(chr);
+                    continue;
+                }
+
+                int baitLevel = chr.getFishingBait();
+                if(baitLevel > 0)
+                    Fishing.doFishing(chr, baitLevel);
             }
         }
     }

--- a/src/main/java/tools/packets/Fishing.java
+++ b/src/main/java/tools/packets/Fishing.java
@@ -24,6 +24,7 @@ import config.YamlConfig;
 import constants.id.ItemId;
 import constants.id.MapId;
 import constants.inventory.ItemConstants;
+import net.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import server.ItemInformationProvider;
@@ -38,37 +39,49 @@ import java.util.Calendar;
 public class Fishing {
     private static final Logger log = LoggerFactory.getLogger(Fishing.class);
 
-    private static double getFishingLikelihood(int x) {
-        return 50.0 + 7.0 * (7.0 * Math.sin(x)) * (Math.cos(Math.pow(x, 0.777)));
+    private static double getFishingLikelihoodDay(int x) {
+        //Sunday, Saturday 2x
+        //Monday-Wednesday-Friday 1.5x
+        //Tuesday-Thursday 1x
+        return switch (x) {
+            case 0, 6 -> 25.0;
+            case 1, 3, 5 -> 18.75;
+            default -> 12.5;
+        };
+    }
+
+    private static double getFishingLikelihoodTime(int x) {
+        //Peak fishing at 7-9:59am, 2-4:59pm, 9-11:59pm
+        return switch (x) {
+            case 7, 8, 9, 14, 15, 16, 21, 22, 23 -> 10.0;
+            default -> 5.0;
+        };
     }
 
     public static double[] fetchFishingLikelihood() {
         Calendar calendar = Calendar.getInstance();
-        int dayOfYear = calendar.get(Calendar.DAY_OF_YEAR);
+            int dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK);
+            int hours = calendar.get(Calendar.HOUR_OF_DAY);
 
-        int hours = calendar.get(Calendar.HOUR);
-        int minutes = calendar.get(Calendar.MINUTE);
-        int seconds = calendar.get(Calendar.SECOND);
-
-        double yearLikelihood = getFishingLikelihood(dayOfYear);
-        double timeLikelihood = getFishingLikelihood(hours + minutes + seconds);
+            double yearLikelihood = getFishingLikelihoodDay(dayOfWeek);
+            double timeLikelihood = getFishingLikelihoodTime(hours);
 
         return new double[]{yearLikelihood, timeLikelihood};
     }
 
-    private static boolean hitFishingTime(Character chr, int baitLevel, double yearLikelihood, double timeLikelihood) {
-        double baitLikelihood = 0.0002 * chr.getWorldServer().getFishingRate() * baitLevel;   // can improve 10.0 at "max level 50000" on rate 1x
+    // You will likely need to tweak this performance based on how you choose to implement your rewards
+    private static boolean hitFishingTime(Character chr, int baitLevel) {
+        double [] likelihoods = fetchFishingLikelihood();
 
-        if (YamlConfig.config.server.USE_DEBUG) {
-            chr.dropMessage(5, "----- FISHING RESULT -----");
-            chr.dropMessage(5, "Likelihoods - Year: " + yearLikelihood + " Time: " + timeLikelihood + " Meso: " + baitLikelihood);
-            chr.dropMessage(5, "Score rolls - Year: " + (0.23 * yearLikelihood) + " Time: " + (0.77 * timeLikelihood) + " Meso: " + baitLikelihood);
-        }
+        double baitLikelihood = baitLevel / 20;
 
-        return (0.23 * yearLikelihood) + (0.77 * timeLikelihood) + (baitLikelihood) > 57.777;
+        // this gives a MINIMUM success rate of 33.75% and a MAXIMUM of 82.5% before fishing rate bonuses.
+        // effectively makes basic bait give a +7.5% success rate, mid gives a +15% success rate, and high gives a +30% success rate
+        // server configuration can give a flat final bonus of +0% to +10%
+        return ((likelihoods[0] + likelihoods[1] + baitLikelihood) * 1.5) + chr.getWorldServer().getFishingRate() > (100.0 * Math.random());
     }
 
-    public static void doFishing(Character chr, int baitLevel, double yearLikelihood, double timeLikelihood) {
+    public static void doFishing(Character chr, int baitLevel) {
         // thanks Fadi, Vcoc for suggesting a custom fishing system
 
         if (!chr.isLoggedinWorld() || !chr.isAlive()) {
@@ -86,117 +99,72 @@ public class Fishing {
         }
 
         String fishingEffect;
-        if (!hitFishingTime(chr, baitLevel, yearLikelihood, timeLikelihood)) {
+        if (!hitFishingTime(chr, baitLevel)) {
             fishingEffect = "Effect/BasicEff.img/Catch/Fail";
         } else {
-            String rewardStr = "";
+
             fishingEffect = "Effect/BasicEff.img/Catch/Success";
 
             int rand = (int) (3.0 * Math.random());
             switch (rand) {
                 case 0:
-                    int mesoAward = (int) (1400.0 * Math.random() + 1201) * chr.getMesoRate() + (15 * chr.getLevel() / 5);
+                    // Meso rewards should be tweaked here for your server's individual game balance
+                    int mesoAward = (int) (1400.0 * Math.random() + 15 * chr.getLevel()) * chr.getMesoRate();
+                    mesoAward = mesoAward/2 * baitLevel/100;
                     chr.gainMeso(mesoAward, true, true, true);
-
-                    rewardStr = mesoAward + " mesos.";
                     break;
                 case 1:
-                    int expAward = (int) (645.0 * Math.random() + 620.0) * chr.getExpRate() + (15 * chr.getLevel() / 4);
+                    // exp rewards should be tweaked here for your server's individual game balance
+                    int expAward = 0;
+                    if(chr.getLevel() <= 50){
+                        expAward = (int) (10 * chr.getLevel() + chr.getLevel() * Math.random()) * chr.getExpRate();
+                    }
+                    else if(chr.getLevel() <= 70){
+                        expAward = (int) (25 * chr.getLevel() + 2*chr.getLevel() * Math.random()) * chr.getExpRate();
+                    }
+                    else if(chr.getLevel() <= 100){
+                        expAward = (int) (100 * chr.getLevel() + 5*chr.getLevel() * Math.random()) * chr.getExpRate();
+                    }
+                    else if(chr.getLevel() <= 150){
+                        expAward = (int) (250 * chr.getLevel() + 10*chr.getLevel() * Math.random()) * chr.getExpRate();
+                    }
+                    else{
+                        expAward = (int) (500 * chr.getLevel() + 25*chr.getLevel() * Math.random()) * chr.getExpRate();
+                    }
+
+                    expAward = expAward/4 * (baitLevel/100);
                     chr.gainExp(expAward, true, true);
 
-                    rewardStr = expAward + " EXP.";
                     break;
                 case 2:
-                    int itemid = getRandomItem();
-                    rewardStr = "a(n) " + ItemInformationProvider.getInstance().getName(itemid) + ".";
+                    int itemid = getRandomItem(baitLevel);
 
                     if (chr.canHold(itemid)) {
+                        if(ItemId.isJackpotFishingDrop(itemid))
+                            Server.getInstance().broadcastMessage(chr.getWorld(), PacketCreator.serverNotice(6, 0, chr.getName() + " found a(n) " + ItemInformationProvider.getInstance().getName(itemid) + " while fishing! Congratulations!"));
                         chr.getAbstractPlayerInteraction().gainItem(itemid, true);
                     } else {
                         chr.showHint("Couldn't catch a(n) #r" + ItemInformationProvider.getInstance().getName(itemid) + "#k due to #e#b" + ItemConstants.getInventoryType(itemid) + "#k#n inventory limit.");
-                        rewardStr += ".. but has goofed up due to full inventory.";
                     }
                     break;
             }
-
-            chr.getMap().dropMessage(6, chr.getName() + " found " + rewardStr);
         }
 
         chr.sendPacket(PacketCreator.showInfo(fishingEffect));
         chr.getMap().broadcastMessage(chr, PacketCreator.showForeignInfo(chr.getId(), fishingEffect), false);
     }
 
-    public static int getRandomItem() {
+    public static int getRandomItem(int baitLevel) {
         int rand = (int) (100.0 * Math.random());
-        int[] commons = {1002851, 2002020, 2002020, ItemId.MANA_ELIXIR, 2000018, 2002018, 2002024, 2002027, 2002027, 2000018, 2000018, 2000018, 2000018, 2002030, 2002018, 2000016}; // filler' up
-        int[] uncommons = {1000025, 1002662, 1002812, 1002850, 1002881, 1002880, 1012072, 4020009, 2043220, 2043022, 2040543, 2044420, 2040943, 2043713, 2044220, 2044120, 2040429, 2043220, 2040943}; // filler' uptoo 
-        int[] rares = {1002859, 1002553, 1002762, 1002763, 1002764, 1002765, 1002766, 1002663, 1002788, 1002949, 2049100, 2340000, 2040822, 2040822, 2040822, 2040822}; // filler' uplast 
+        int baitBonus = baitLevel / 100;
+        rand -= baitBonus; // gives a +1% / +2% / +4% shot at a non-common item
 
         if (rand >= 25) {
-            return commons[(int) (commons.length * Math.random())];
-        } else if (rand <= 7 && rand >= 4) {
-            return uncommons[(int) (uncommons.length * Math.random())];
+            return ItemId.FISHING_REWARDS_COMMON[(int) (ItemId.FISHING_REWARDS_COMMON.length * Math.random())];
+        } else if (rand >= 4) {
+            return ItemId.FISHING_REWARDS_UNCOMMON[(int) (ItemId.FISHING_REWARDS_UNCOMMON.length * Math.random())];
         } else {
-            return rares[(int) (rares.length * Math.random())];
+            return ItemId.FISHING_REWARDS_RARE[(int) (ItemId.FISHING_REWARDS_RARE.length * Math.random())];
         }
-    }
-
-    private static void debugFishingLikelihood() {
-        long[] a = new long[365], b = new long[365];
-        long hits = 0, hits10 = 0, total = 0;
-
-        for (int i = 0; i < 365; i++) {
-            double yearLikelihood = getFishingLikelihood(i);
-
-            int dayHits = 0, dayHits10 = 0;
-            for (int k = 0; k < 24; k++) {
-                for (int l = 0; l < 60; l++) {
-                    for (int m = 0; m < 60; m++) {
-                        double timeLikelihood = getFishingLikelihood(k + l + m);
-
-                        if ((0.23 * yearLikelihood) + (0.77 * timeLikelihood) > 57.777) {
-                            hits++;
-                            dayHits++;
-                        }
-
-                        if ((0.23 * yearLikelihood) + (0.77 * timeLikelihood) + 10.0 > 57.777) {
-                            hits10++;
-                            dayHits10++;
-                        }
-
-                        total++;
-                    }
-                }
-            }
-
-            a[i] = dayHits;
-            b[i] = dayHits10;
-        }
-
-        long maxhit = 0, minhit = Long.MAX_VALUE;
-        for (int i = 0; i < 365; i++) {
-            if (maxhit < a[i]) {
-                maxhit = a[i];
-            }
-
-            if (minhit > a[i]) {
-                minhit = a[i];
-            }
-        }
-
-        long maxhit10 = 0, minhit10 = Long.MAX_VALUE;
-        for (int i = 0; i < 365; i++) {
-            if (maxhit10 < b[i]) {
-                maxhit10 = b[i];
-            }
-
-            if (minhit10 > b[i]) {
-                minhit10 = b[i];
-            }
-        }
-
-        log.debug("Diary   min {} max {}", minhit, maxhit);
-        log.debug("Diary10 min {} max {}", minhit10, maxhit10);
-        log.debug("Hits: {}, Hits10: {}, Total: {} -- %1000 {}, +10 %1000: {}", hits, hits10, total, (hits * 1000 / total), (hits10 * 1000 / total));
     }
 } 


### PR DESCRIPTION
No guarantees on this.\
This is meant to illustrate a simple implementation of afk fishing and how you can add some rewards and randomness.\
In the server I originally did this work for, Fishing was meant to be highly rewarding (bait was only rewarded via voting points).\
You should THOUROUGHLY test and make needed adjustments to rewards before implementing this on any server.\
Many improvements could (and should) be made to this to avoid long lists of item ids in static maps.\
The bonuses based on time/day of week were aimed at providing the best results of fishing during peak hours.